### PR TITLE
Fixes build failures on Solaris-derived systems

### DIFF
--- a/tsacmd/dialer_unix.go
+++ b/tsacmd/dialer_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build linux darwin solaris
 
 package tsacmd
 


### PR DESCRIPTION
Nothing fancy here, just correcting a minor oversight that prevented builds on Solaris and hosts of that family (SmartOS, Illumos, etc).